### PR TITLE
Add additional user agent metadata for the SSO auth code flow

### DIFF
--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3067,6 +3067,7 @@ class BaseSSOTokenFetcher(object):
     """
     _EXPIRY_WINDOW = 15 * 60
     _CLIENT_REGISTRATION_TYPE = 'public'
+    _USER_AGENT_EXTRA = None
 
     def __init__(
             self, sso_region, client_creator, cache=None,
@@ -3122,6 +3123,7 @@ class BaseSSOTokenFetcher(object):
         config = botocore.config.Config(
             region_name=self._sso_region,
             signature_version=botocore.UNSIGNED,
+            user_agent_extra=self._USER_AGENT_EXTRA,
         )
         return self._client_creator('sso-oidc', config=config)
 
@@ -3364,6 +3366,7 @@ class SSOTokenFetcherAuth(BaseSSOTokenFetcher):
     """Performs the authorization code grant with PKCE OAuth2.0 flow"""
     _AUTH_GRANT_TYPES = ('authorization_code', 'refresh_token')
     _AUTH_GRANT_DEFAULT_SCOPE = 'sso:account:access'
+    _USER_AGENT_EXTRA = 'md/sso#auth'
 
     def __init__(
         self,

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -516,3 +516,17 @@ class TestLoginCommand(BaseSSOTest):
             stderr
         )
 
+    def test_login_device_no_extra_user_agent(self):
+        self.add_oidc_device_responses(self.access_token)
+        self.run_cmd('sso login --use-device-code')
+        self.assertNotIn('md/sso#auth',
+                         self.last_request_dict['headers']['User-Agent'])
+
+    def test_login_auth_includes_extra_user_agent(self):
+        content = self.get_sso_session_config('test-session')
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assertIn('md/sso#auth',
+                      self.last_request_dict['headers']['User-Agent'])
+


### PR DESCRIPTION
_Description of changes:_ Small addition to https://github.com/aws/aws-cli/pull/8947 on a separate PR since that one is already approved. This adds a metadata entry to the user agent when the auth code flow is used for SSO as opposed to the device code grant. This will aid troubleshooting if we don't have access to the command options, as well as potentially route outreach via the AWS Personal Health Dashboard if ever necessary.

Note: Planning to merge into `v2` via the existing PR, but cutting this separately to show the addition.